### PR TITLE
Fix read and touch file

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -52,13 +52,13 @@ class File {
 	 * @throws FileException when something goes wrong
 	 */
 	public function touch($created = null, $lastAccessed = null) {
-		$created = $created instanceof DateTime 
+		$created = $created instanceof DateTime
 			? $created->getTimestamp() 
-			: $created === null ? time() : $created;
+			: ($created === null ? time() : $created);
 		$lastAccessed = $lastAccessed instanceof DateTime
 			? $lastAccessed->getTimestamp()
-			: $lastAccessed === null ? time() : $lastAccessed;
-		
+			: ($lastAccessed === null ? time() : $lastAccessed);
+
 		if (!@touch($this->pathname, $created, $lastAccessed)) {
 			throw new FileException(sprintf('Failed to touch file at %s', $this->pathname));
 		}

--- a/src/File.php
+++ b/src/File.php
@@ -23,6 +23,10 @@ class File {
 			throw new FileException(sprintf('File does not exist: %s', $this->getFilename()));
 		}
 
+		if (!$this->isReadable()) {
+			throw new FileException(sprintf('You don\'t have permissions to access %s file', $this->getFilename()));
+		}
+
 		return file_get_contents($this->pathname);
 	}
 

--- a/src/FileOperationTrait.php
+++ b/src/FileOperationTrait.php
@@ -86,7 +86,7 @@ trait FileOperationTrait {
 	 * @return DateTime
 	 */
 	public function getCreatedAt() {
-		$timestamp = filectime($this->pathname);
+		$timestamp = filemtime($this->pathname);
 		$time = new DateTime();
 		$time->setTimestamp($timestamp);
 		return $time;

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -105,6 +105,18 @@ class FileTest extends FilesystemTest {
 		$file = new File($this->root->url() . '/dir/composer.json');
 		$file->touch();
 	}
+
+	public function testTouchWithDateTime() {
+		$createDate = new \DateTime('2018-08-27');
+		$modDate = new \DateTime('2018-08-29');
+		$dir = new Directory($this->root->url() . '/dir');
+		$dir->make();
+		$file = new File($this->root->url() . '/dir/composer.json');
+		$file->touch($createDate, $modDate);
+
+		$this->assertEquals($createDate, $file->getCreatedAt());
+		$this->assertEquals($modDate, $file->getLastAccessedAt());
+	}
 	
 	public function testDelete() {
 		$dir = new Directory($this->root->url() . '/dir');

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace phootwork\file\tests;
 
+use org\bovigo\vfs\vfsStream;
 use phootwork\file\Directory;
 use phootwork\file\File;
 use phootwork\file\Path;
@@ -13,6 +14,16 @@ class FileTest extends FilesystemTest {
 		$file->write($json);
 
 		$this->assertEquals($json, $file->read());
+	}
+
+	/**
+	 * @expectedException phootwork\file\exception\FileException
+	 */
+	public function testReadUnreadableFile()
+	{
+		$testFile = vfsStream::newFile('nonreadable.txt', 000)->at($this->root)->setContent('I am not readable.');
+		$file = new File($testFile->url());
+		$file->read();
 	}
 	
 	/**


### PR DESCRIPTION
When try to read an "unreadable" file, `file_get_contents` function rises an error and php stops the execution. 
With this commit, if the file is not readable, a `FileException` exception is thrown.

Fix `touch` method when `\DateTime` objects are passed as parameters.